### PR TITLE
ANSI reset

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -50,6 +50,7 @@ int main(int argc, char **argv)
 // callback function for signals
 void clean_up(int i)
 {
+   cout << ANSI_RESET_STR << endl << ends;
    if (colortail)
       delete colortail;
    exit(1);


### PR DESCRIPTION
Terminal should receive an ansi reset when the program is interrupted,
or the color set by colortail will remain in the shell.
