### PR TITLE
autogen.sh: interpreter added

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 aclocal
 automake --add-missing
 autoconf


### PR DESCRIPTION
Without this, `./autogen.sh` doesn’t work on OS X Mountain Lion.